### PR TITLE
Enable diacritics in emote names and sets

### DIFF
--- a/structures/v3/structures.go
+++ b/structures/v3/structures.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	RegExpEmoteName               = regexp.MustCompile(`^[-_A-Za-z(!?&)$+:0-9]{2,100}$`)
-	RegExpEmoteVersionName        = regexp.MustCompile(`^[A-Za-z0-9\s]{2,40}$`)
-	RegExpEmoteVersionDescription = regexp.MustCompile(`^[-_*=/\\"'\]\[}{@&~!?;:A-Za-z0-9\s]{3,240}$`)
+	RegExpEmoteName               = regexp.MustCompile(`^[-_A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ(!?&)$+:0-9]{2,100}$`)
+	RegExpEmoteVersionName        = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{2,40}$`)
+	RegExpEmoteVersionDescription = regexp.MustCompile(`^[-_*=/\\"'\]\[}{@&~!?;:A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{3,240}$`)
 )
 
 type UpdateMap bson.M

--- a/structures/v3/structures.go
+++ b/structures/v3/structures.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	RegExpEmoteName               = regexp.MustCompile(`^[-_A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ(!?&)$+:0-9]{2,100}$`)
-	RegExpEmoteVersionName        = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{2,40}$`)
-	RegExpEmoteVersionDescription = regexp.MustCompile(`^[-_*=/\\"'\]\[}{@&~!?;:A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{3,240}$`)
+	RegExpEmoteName               = regexp.MustCompile(`^[-_A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴǵǸ-țȞȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤƥƫ-ưƲ-ƶẠ-ỿ(!?&)$+:0-9]{2,100}$`)
+	RegExpEmoteVersionName        = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴǵǸ-țȞȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{2,40}$`)
+	RegExpEmoteVersionDescription = regexp.MustCompile(`^[-_*=/\\"'\]\[}{@&~!?;:A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴǵǸ-țȞȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤƥƫ-ưƲ-ƶẠ-ỿ0-9\s]{3,240}$`)
 )
 
 type UpdateMap bson.M

--- a/structures/v3/validator.emote_set.go
+++ b/structures/v3/validator.emote_set.go
@@ -10,7 +10,7 @@ type EmoteSetValidator struct {
 	v *EmoteSet
 }
 
-var RegExpEmoteSetName = regexp.MustCompile(`^[a-zA-Z0-9&'_-~# ]{1,40}$`)
+var RegExpEmoteSetName = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9&'_-~# ]{1,40}$`)
 
 func (e *EmoteSet) Validator() EmoteSetValidator {
 	return EmoteSetValidator{e}

--- a/structures/v3/validator.emote_set.go
+++ b/structures/v3/validator.emote_set.go
@@ -10,7 +10,7 @@ type EmoteSetValidator struct {
 	v *EmoteSet
 }
 
-var RegExpEmoteSetName = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9&'_-~# ]{1,40}$`)
+var RegExpEmoteSetName = regexp.MustCompile(`^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴǵǸ-țȞȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤƥƫ-ưƲ-ƶẠ-ỿ0-9&'_-~# ]{1,40}$`)
 
 func (e *EmoteSet) Validator() EmoteSetValidator {
 	return EmoteSetValidator{e}


### PR DESCRIPTION
Should match all diacritics without any extra characters like `\pL`
I wasn't sure whether or not to add it to tags as well, if that's wanted it could be adapted to be added there as well